### PR TITLE
Extend the optionset to include ref

### DIFF
--- a/knockout-bind-react.js
+++ b/knockout-bind-react.js
@@ -22,6 +22,10 @@
           React.createElement(options.component, options.props),
           element
         );
+        
+        if (options.ref) {
+          options.ref(componentInstance);
+        }
       }
     }
   };


### PR DESCRIPTION
The ref parameter expects a function which will be given the instance to the rendered component.